### PR TITLE
fix segfault when exiting the program.

### DIFF
--- a/include/lib.h
+++ b/include/lib.h
@@ -22,7 +22,7 @@
 extern int pthread_mutexattr_settype(pthread_mutexattr_t *, int);
 typedef void *(*pfunc_t)(void *);
 extern pthread_t threads[];
-extern int newthread(pfunc_t thread_func);
+extern pthread_t newthread(pfunc_t thread_func);
 
 #define gettid() syscall(SYS_gettid)
 

--- a/shell/main.c
+++ b/shell/main.c
@@ -19,7 +19,7 @@ extern void tcp_timer(void);
  */
 pthread_t threads[4];
 
-int newthread(pfunc_t thread_func)
+pthread_t newthread(pfunc_t thread_func)
 {
 	pthread_t tid;
 	if (pthread_create(&tid, NULL, thread_func, NULL))


### PR DESCRIPTION
The type conversion altered `tid`, resulting in an error at `pthread_cancel()`.